### PR TITLE
fea: added export migrations

### DIFF
--- a/database/migrations/2025_01_06_010413_create_imports_table.php
+++ b/database/migrations/2025_01_06_010413_create_imports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('imports', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_name');
+            $table->string('file_path');
+            $table->string('importer');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('imports');
+    }
+};

--- a/database/migrations/2025_01_06_010414_create_exports_table.php
+++ b/database/migrations/2025_01_06_010414_create_exports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exports', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_disk');
+            $table->string('file_name')->nullable();
+            $table->string('exporter');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exports');
+    }
+};

--- a/database/migrations/2025_01_06_010415_create_failed_import_rows_table.php
+++ b/database/migrations/2025_01_06_010415_create_failed_import_rows_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_import_rows', function (Blueprint $table) {
+            $table->id();
+            $table->json('data');
+            $table->foreignId('import_id')->constrained()->cascadeOnDelete();
+            $table->text('validation_error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_import_rows');
+    }
+};


### PR DESCRIPTION
This pull request introduces new database migration files to support the import and export functionalities. The most important changes include creating tables for imports, exports, and failed import rows.

Database migrations:

* [`database/migrations/2025_01_06_010413_create_imports_table.php`](diffhunk://#diff-935d71340db19c6a8894dc44c939fe5bc66eed452c3803448931e9668cb9a5bdR1-R35): Added a migration to create the `imports` table with columns for file details, processing status, and user association.
* [`database/migrations/2025_01_06_010414_create_exports_table.php`](diffhunk://#diff-87c13ca3eff45b165b13d257048113dd8d80e24f25decf69cbf5133599a86588R1-R35): Added a migration to create the `exports` table with columns for file details, processing status, and user association.
* [`database/migrations/2025_01_06_010415_create_failed_import_rows_table.php`](diffhunk://#diff-f5aaca95f1856f35139347975a76f621317d5391bc55c4b6b55caf7a060ac9f7R1-R30): Added a migration to create the `failed_import_rows` table with columns for storing failed row data, associated import ID, and validation errors.